### PR TITLE
fix: use standard configuration directory

### DIFF
--- a/pyrenamer/pyrenamer.py
+++ b/pyrenamer/pyrenamer.py
@@ -66,7 +66,7 @@ from tools import filetools as renamerfilefuncs
 from tools import undo
 
 
-config_dir = os.path.join(os.path.expanduser("~"), "config/pyRenamer")
+config_dir = os.path.join(os.path.expanduser("~"), ".config/pyRenamer")
 
 
 class pyRenamer:


### PR DESCRIPTION
For some reason, this app is using a non-standard directory to store the configuration.
The majority of the files here mention using the standard directory, but the app itself is not using it.